### PR TITLE
add version 1.1.3

### DIFF
--- a/boost.lua
+++ b/boost.lua
@@ -1,11 +1,11 @@
 
-
+--[[
 boost( data.raw["recipe"]["insulated-cable"] )
 
 boost( data.raw["recipe"]["iron-stick"] )
 boost( data.raw["recipe"]["iron-gear-wheel"] )
 boost( data.raw["recipe"]["copper-cable"] )
-
+--]]
 --[[
 boost( data.raw["recipe"]["steel-bearing-ball"])
 boost( data.raw["recipe"]["cobalt-steel-bearing-ball"])
@@ -45,7 +45,7 @@ boost( data.raw["recipe"]["tungsten-gear-wheel"] )
 boost( data.raw["recipe"]["nitinol-gear-wheel"] )
 
 --]]
-
+--[[
 boost( data.raw["recipe"]["angels-wire-gold"] )
 boost( data.raw["recipe"]["basic-tinned-copper-wire"] )
 
@@ -63,4 +63,4 @@ boostPattern('bearing');
 
 -- ensure the mod won't crash if a recipe is missing
 boost( data.raw["recipe"]["invalid-recipe-test"] )
-
+--]]

--- a/boostfinal.lua
+++ b/boostfinal.lua
@@ -1,17 +1,17 @@
 
-boost( data.raw["recipe"]["wooden-board"] )
-boost( data.raw["recipe"]["phenolic-board"] )
-boost( data.raw["recipe"]["fibreglass-board"] )
-boost( data.raw["recipe"]["basic-circuit-board"] )
-boost( data.raw["recipe"]["electronic-circuit"] )
-boost( data.raw["recipe"]["silicon-wafer"] )
-boost( data.raw["recipe"]["cp-electronic-circuit-board"] )
-boost( data.raw["recipe"]["rocket-engine"] )
-boost( data.raw["recipe"]["angels-glass-fiber-board"] )
-boost( data.raw["recipe"]["solid-rubber"] )
-
-
-boostPattern('angelsore.-processing');
+--boost( data.raw["recipe"]["wooden-board"] )
+--boost( data.raw["recipe"]["phenolic-board"] )
+--boost( data.raw["recipe"]["fibreglass-board"] )
+--boost( data.raw["recipe"]["basic-circuit-board"] )
+--boost( data.raw["recipe"]["electronic-circuit"] )
+--boost( data.raw["recipe"]["silicon-wafer"] )
+--boost( data.raw["recipe"]["cp-electronic-circuit-board"] )
+--boost( data.raw["recipe"]["rocket-engine"] )
+--boost( data.raw["recipe"]["angels-glass-fiber-board"] )
+--boost( data.raw["recipe"]["solid-rubber"] )
+--
+--
+--boostPattern('angelsore.-processing');
 
 -- Make void recipes longer to reduce the UPS cost of dynamically selecting void recipes
 boostPattern('-void-', 60, 40);
@@ -31,7 +31,7 @@ if clarifier then
 end
 
 -- uncomment to boost all recipe
--- boostall(data.raw["recipe"])
+boostall(data.raw["recipe"])
 
 local function resetProdBonus()
   for index, force in pairs(game.forces) do

--- a/boostfunction.lua
+++ b/boostfunction.lua
@@ -37,7 +37,7 @@ function boostRecipe (a, name, rootBoostFactor, targetTime, minimumTime)
 	targetTime = targetTime or BOOST_TARGET_TIME
 	minimumTime = minimumTime or MINIMUM_ENERGY_REQUIRED
 
-	infoLog ("boost check on  ".. name .." with root boost factor ".. rootBoostFactor)
+	debugLog ("boost check on  ".. name .." with root boost factor ".. rootBoostFactor)
 
 	local boostFactor = 1
 	if( rootBoostFactor ~= NO_BOOST_APPLIED ) then

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+1.1.3
+	- Boost all recipe to a minimum of 2 seconds so that no recipe gets speed limited by ticks.
+	- Fixes the productivity beacon bug with catalyst production.
+
 1.1.2
 	- Boost Solid Rubber from Liquid Rubber Recipe
 	- Boost all void recipe to take 60 seconds to reduce UPS cost of furnace dynamically picking recipes

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "duff-seablock-megabase",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "factorio_version": "1.1",
   "title": "Seablock Megabase Fixes",
   "author": "D-Duff",


### PR DESCRIPTION
1.1.3
	- Boost all recipe to a minimum of 2 seconds so that no recipe gets speed limited by ticks.
	- Fixes the productivity beacon bug with catalyst production.